### PR TITLE
Add parameter to ignore same route params

### DIFF
--- a/src/writeHistory.js
+++ b/src/writeHistory.js
@@ -13,6 +13,7 @@ export default (to, from) => {
         /**
          * Save the new route
          */
+        if (History.ignoreSameRouteParams && to.name && from.name && to.name === from.name) return
         History.push(to.fullPath)
     }
 }


### PR DESCRIPTION
With this option, navigations to the same route with different params don't get recorded. Useful for navigating prev/next items and having a back button that goes back to the previous/parent page and not previous items.

```js
import { routerHistory } from 'vue-router-back-button'
routerHistory.ignoreSameRouteParams = true
```