### PR TITLE
Add replace route support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,18 @@ Vue.use(VueRouterBackButton, {
 })
 ```
 
+### Replacing routes
+
+If you want to replace the route e.g. `$router.replace()` you will need to pass a query parameter `replaceRoute=true`. This is a workaround due to [this issue in vue-router](https://github.com/vuejs/vue-router/issues/1620).
+
+```
+$router.replace('/edit?replaceRoute=true')
+```
+
+> **NOTE**:
+> The package will ignore this query parameter when comparing routes.
+> Technically you can still use `$router.push()` as long as the query parameter is `replaceRoute=true`. This behaviour is **not guaranteed** for future versions as this is a side effect due to the workaround used.
+
 ## Documentation
 
 | Function | Description |

--- a/src/history.js
+++ b/src/history.js
@@ -196,6 +196,24 @@ const History = {
         }
 
         this.save()
+	},
+
+	/**
+     * Replace last route in the history
+     */
+    replace (path) {
+        this._history = this.getHistory()
+        this._current = this.getCurrent()
+
+        this._history.splice(this._current + 1, this._history.length)
+
+		const currentPath = this._history[this._history.length - 1]
+
+        if (currentPath !== path) {
+            this._history[this._history.length - 1] = path
+        }
+
+        this.save()
     },
 
     /**

--- a/src/utils/removeParameterFromUrl.js
+++ b/src/utils/removeParameterFromUrl.js
@@ -1,0 +1,6 @@
+// REFERENCE: https://stackoverflow.com/a/25214672
+export default function removeParameterFromUrl(url, parameter) {
+	return url
+		.replace(new RegExp('[?&]' + parameter + '=[^&#]*(#.*)?$'), '$1')
+		.replace(new RegExp('([?&])' + parameter + '=[^&]*&'), '$1');
+}

--- a/src/writeHistory.js
+++ b/src/writeHistory.js
@@ -1,8 +1,10 @@
 import History from './history'
+import removeParameterFromUrl from './utils/removeParameterFromUrl'
 
 export default (to, from) => {
-    if (History.visitedRecently(to.fullPath)) {
-        const amount = History.indexOfRecentHistory(to.fullPath)
+	const fullPath = removeParameterFromUrl(to.fullPath, 'replaceRoute')
+    if (History.visitedRecently(fullPath)) {
+        const amount = History.indexOfRecentHistory(fullPath)
 
         History.back(amount)
     } else {
@@ -11,11 +13,19 @@ export default (to, from) => {
          */
         if (History.ignoreRoutesWithSameName && to.name && from.name && to.name === from.name) {
             return
-        }
+		}
+
+		if (to && to.query && to.query.replaceRoute) {
+			/**
+			 * Replace the last route
+			 */
+			History.replace(fullPath)
+			return
+		}
 
         /**
          * Save the new route
          */
-        History.push(to.fullPath)
+        History.push(fullPath)
     }
 }

--- a/tests/feature/router.spec.js
+++ b/tests/feature/router.spec.js
@@ -102,5 +102,50 @@ describe('vue-router', () => {
 
         expect(routerHistory.previous().path).toEqual('/1')
         expect(routerHistory.next().path).toEqual(undefined)
+	})
+
+	test('it can replace the route', () => {
+        $router.push('/index')
+        $router.push('/show')
+		$router.replace({name: 'edit', query: { replaceRoute: true }})
+
+        expect(routerHistory.previous().path).toEqual('/index')
+        expect(routerHistory.current().path).toEqual('/edit')
+	})
+	test('it can replace the route when url with query param is used', () => {
+        $router.push('/index')
+        $router.push('/show')
+		$router.replace('/edit?replaceRoute=true')
+
+        expect(routerHistory.previous().path).toEqual('/index')
+        expect(routerHistory.current().path).toEqual('/edit')
+	})
+
+	test('it can replace the route when other query params are present', () => {
+        $router.push('/index')
+        $router.push('/show')
+		$router.replace({name: 'edit', query: { replaceRoute: true, someParam: "test" }})
+
+        expect(routerHistory.previous().path).toEqual('/index')
+        expect(routerHistory.current().path).toEqual('/edit?someParam=test')
     })
+
+	test('it can detect correct route sequence after replacing the route', () => {
+        $router.push('/index')
+        $router.push('/show')
+        $router.push('/edit')
+		$router.replace({name: 'show', query: { replaceRoute: true }})
+
+        expect(routerHistory.previous().path).toEqual('/index')
+        expect(routerHistory.current().path).toEqual('/show')
+	})
+
+	test('it can replace the route when url with query param is used, even when using $router.push() instead of $router.replace()', () => {
+        $router.push('/index')
+        $router.push('/show')
+		$router.push('/edit?replaceRoute=true')
+
+        expect(routerHistory.previous().path).toEqual('/index')
+        expect(routerHistory.current().path).toEqual('/edit')
+	})
 })

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -1,0 +1,24 @@
+import removeParameterFromUrl from '@/utils/removeParameterFromUrl'
+
+describe('removeParameterFromUrl', () => {
+	const someUrl = '/some-url'
+    test('it removes query parameter when present', () => {
+		const url = removeParameterFromUrl(someUrl + '?replaceRoute=true', 'replaceRoute')
+        expect(url).toEqual(someUrl)
+	})
+
+	test('it removes the correct query parameter when more than 1 query param is present ', () => {
+		const url = removeParameterFromUrl(someUrl + '?replaceRoute=true&someParam=1', 'replaceRoute')
+        expect(url).toEqual(someUrl + '?someParam=1')
+	})
+
+	test('it removes the correct query parameter when more than 1 query param is present and param to replace is last ', () => {
+		const url = removeParameterFromUrl(someUrl + '?someParam=1&replaceRoute=true', 'replaceRoute')
+        expect(url).toEqual(someUrl + '?someParam=1')
+	})
+
+	test('it removes the correct query parameter when more than 1 query param is present and param to replace is not first and not last ', () => {
+		const url = removeParameterFromUrl(someUrl + '?someParam=1&replaceRoute=true&someOtherParam=2', 'replaceRoute')
+        expect(url).toEqual(someUrl + '?someParam=1&someOtherParam=2')
+	})
+})


### PR DESCRIPTION
I noticed this package didn't support `$router.replace()`, so I added it. 

I had to use a workaround using query parameter due to this issue: [ability to check push vs replace in navigation guard in vue-router](https://github.com/vuejs/vue-router/issues/1620)