### PR TITLE
Issue with replace and undo history

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -220,18 +220,20 @@ const History = {
      * Add new route to the history
      */
     push (path) {
-        this._history = this.getHistory()
-        this._current = this.getCurrent()
         this._undo = {
             history: this._history,
             current: this._current,
         }
+        
+        this._history = this.getHistory()
+        this._current = this.getCurrent()
 
         this._history.splice(this._current + 1, this._history.length)
 
         const currentPath = this._history[this._history.length - 1]
 
         if (currentPath !== path) {
+            this._undo.history.push(path)
             this._history.push(path)
             this._current = this._current + 1
         }
@@ -245,6 +247,7 @@ const History = {
      */
     undoPush () {
         if (this._undo && this._undo.hasOwnProperty('history') && this._undo.hasOwnProperty('current')) {
+            this._undo.history.splice(this._undo.current, 1);
             this._history = this._undo.history
             this._current = this._undo.current
     

--- a/tests/feature/router.spec.js
+++ b/tests/feature/router.spec.js
@@ -78,6 +78,14 @@ describe('vue-router', () => {
         expect(routerHistory.previous().path).toEqual('/index')
     })
 
+    test('it ignores the route when it was replaced and should replace it in the undo history array', () => {
+        push('/index')
+        push('/show')
+        replace('/edit')
+
+        expect(routerHistory._undo.history).toEqual(['/index', '/edit'])
+    })
+
     test('it can go back to routes with the same name', () => {
         routerHistory.ignoreRoutesWithSameName = false
 

--- a/tests/feature/router.spec.js
+++ b/tests/feature/router.spec.js
@@ -86,6 +86,14 @@ describe('vue-router', () => {
         expect(routerHistory._undo.history).toEqual(['/index', '/edit'])
     })
 
+    test('it ignores the route when it was replaced and should maintain undo current index', () => {
+        push('/index')
+        push('/show')
+        replace('/edit')
+
+        expect(routerHistory._undo.current).toEqual(1)
+    })
+
     test('it can go back to routes with the same name', () => {
         routerHistory.ignoreRoutesWithSameName = false
 


### PR DESCRIPTION
I noticed an issue where replace wasn't always working the way i expected and struggled to replicate until i realised what was going on.

If you navigate like so

```js
push('/index');
push('/about');
replace('/hello');

//expected
{history: ['/index', '/hello'], current: 1}

//actual
{history: ['/index', '/about', '/hello'], current: 1}
```

Because the `current` is correct it actually works as expected and passes all tests. But if you do a full page refresh the `current` will change to 2 and the `previous.path` will incorrectly point to `/hello` again.

I've added two tests to show this and implemented a fix, let me know your thoughts.